### PR TITLE
1 - Because of Strict Standards, inherited classes should have the same signature for overrided methods, so PHP displays error if you don't do it. So I edited the media/* files to fix that.

### DIFF
--- a/class/fromMedia.php
+++ b/class/fromMedia.php
@@ -102,9 +102,11 @@ abstract class fromMedia {
     
     protected function save() {
         $this->lastTS = time();
-        file_put_contents($this->cacheFileName, json_encode(array(
-            'ts'    => $this->lastTS,
-            'itens' => $this->lastItens
-        )));
+        if(is_writable($this->cacheFileName)) {
+            file_put_contents($this->cacheFileName, json_encode(array(
+                'ts'    => $this->lastTS,
+                'itens' => $this->lastItens
+            )));
+        }
     }
 }

--- a/medias/BBCTech.php
+++ b/medias/BBCTech.php
@@ -21,7 +21,7 @@ class fromBBCTech extends fromMedia {
      * @param int $stop
      * @return array
      */
-    public function getItens($stop = 10) {
+    public function getItens($stop = 10, $function = null) {
         $fn = function(&$item) {
             $item['href']     = str_replace('tag:', 'http://', $item['href']);
             $item['ts']       = strtotime($item['datetime']);

--- a/medias/ExameTech.php
+++ b/medias/ExameTech.php
@@ -21,7 +21,7 @@ class fromExameTech extends fromMedia {
      * @param int $stop
      * @return array
      */
-    public function getItens($stop = 10) {
+    public function getItens($stop = 10, $function = null) {
         $fn = function(&$item) {
             $aux = html_entity_decode($item['subtitulo']);
             $aux = strip_tags($aux, '<p></p>');

--- a/medias/IGNTech.php
+++ b/medias/IGNTech.php
@@ -21,7 +21,7 @@ class fromIGNTech extends fromMedia {
      * @param int $stop
      * @return array
      */
-    public function getItens($stop = 10) {
+    public function getItens($stop = 10, $function = null) {
         $fn = function(&$item) {
             preg_match('~url\(\'([^\']+)\'\)~', $item['img'], $aux);
             $img = $aux[1];

--- a/medias/TechTudo.php
+++ b/medias/TechTudo.php
@@ -21,7 +21,7 @@ class fromTechTudo extends fromMedia {
      * @param int $stop
      * @return array
      */
-    public function getItens($stop = 10) {
+    public function getItens($stop = 10, $function = null) {
         $fn = function(&$item) {
             $item['ts']       = strtotime($item['datetime']);
             $item['datetime'] = date($this->patternDate, $item['ts']);


### PR DESCRIPTION
2 - Fixed a warning in fromMedia.php because php may not have permission
to write in the cache files.
